### PR TITLE
Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -2,6 +2,9 @@ name: macOS-CI
 
 run-name: "${{ github.ref_name }} - ${{ github.run_number }}"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/PowerShell/security/code-scanning/48](https://github.com/ReuelAlbert-Dev/PowerShell/security/code-scanning/48)

Add an explicit `permissions` block in `.github/workflows/macos-ci.yml` to enforce least privilege.  
Best single fix without changing behavior is to set workflow-level minimal permissions:

- `contents: read` (recommended baseline, and sufficient for checkout/read operations).
  
This addresses the CodeQL finding for all jobs that do not override permissions and documents intent. If any job later needs write scopes, add job-specific overrides only for that job.

**Where to change:**
- File: `.github/workflows/macos-ci.yml`
- Insert `permissions:` near the top level (after `run-name` and before `on:` is a clean location).

No imports/methods/dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
