### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-markdown-links.yml
+++ b/.github/workflows/verify-markdown-links.yml
@@ -16,6 +16,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify-markdown-links:
     timeout-minutes: 10  # Prevents hanging workflows


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/PowerShell/security/code-scanning/49](https://github.com/ReuelAlbert-Dev/PowerShell/security/code-scanning/49)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions directly under `workflow_dispatch` (before `jobs`) with `contents: read`, which is sufficient for checkout and read-only link verification in this file as shown.

**File to edit:** `.github/workflows/verify-markdown-links.yml`  
**Change location:** between the `on:` block and the `jobs:` block.  
**No imports, methods, or dependencies are needed** (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
